### PR TITLE
Added config option to change Terminal

### DIFF
--- a/lib/gcc-make-run.coffee
+++ b/lib/gcc-make-run.coffee
@@ -67,6 +67,13 @@ module.exports = GccMakeRun =
       default: false
       order: 9
       description: 'Turn on this flag to log the executed command and output in console'
+    'terminal':
+      title: 'Select terminal'
+      type: 'string'
+      default: 'xterm'
+      order: 10
+      description: 'Select terminal to use on Linux EX. "xterm" [default] or "konsole"'
+
   gccMakeRunView: null
   oneTimeBuild: false
 
@@ -219,17 +226,17 @@ module.exports = GccMakeRun =
     # get config
     mk = atom.config.get('gcc-make-run.make')
     info.env = _extend({ ARGS: atom.config.get('gcc-make-run.args') }, process.env)
-
+    terminal = atom.config.get('gcc-make-run.terminal')
     if info.useMake
       switch process.platform
         when 'win32' then info.cmd = "start \"#{info.exe}\" cmd /c \"\"#{mk}\" -sf \"#{info.base}\" run & pause\""
-        when 'linux' then info.cmd = "xterm -T \"#{info.exe}\" -e \"" + @escdq("\"#{mk}\" -sf \"#{info.base}\" run") + "; read -n1 -p 'Press any key to continue...'\""
+        when 'linux' then info.cmd = "#{terminal} -T \"#{info.exe}\" -e \"" + @escdq("\"#{mk}\" -sf \"#{info.base}\" run") + "; read -n1 -p 'Press any key to continue...'\""
         when 'darwin' then info.cmd = 'osascript -e \'tell application "Terminal" to activate do script "' + @escdq("clear && cd \"#{info.dir}\"; \"#{mk}\" ARGS=\"#{@escdq(info.env.ARGS)}\" -sf \"#{info.base}\" run; " + 'read -n1 -p "Press any key to continue..." && osascript -e "tell application \\"Atom\\" to activate" && osascript -e "do shell script ' + @escdq("\"osascript -e #{@escdq('"tell application \\"Terminal\\" to close windows 0"')} + &> /dev/null &\"") + '"; exit') + '"\''
     else
       # normal run
       switch process.platform
         when 'win32' then info.cmd = "start \"#{info.exe}\" cmd /c \"\"#{info.exe}\" #{info.env.ARGS} & pause\""
-        when 'linux' then info.cmd = "xterm -T \"#{info.exe}\" -e \"" + @escdq("\"./#{info.exe}\" #{info.env.ARGS}") + "; read -n1 -p 'Press any key to continue...'\""
+        when 'linux' then info.cmd = "#{terminal} -T \"#{info.exe}\" -e \"" + @escdq("\"./#{info.exe}\" #{info.env.ARGS}") + "; read -n1 -p 'Press any key to continue...'\""
         when 'darwin' then info.cmd = 'osascript -e \'tell application "Terminal" to activate do script "' + @escdq("clear && cd \"#{info.dir}\"; \"./#{info.exe}\" #{info.env.ARGS}; " + 'read -n1 -p "Press any key to continue..." && osascript -e "tell application \\"Atom\\" to activate" && osascript -e "do shell script ' + @escdq("\"osascript -e #{@escdq('"tell application \\"Terminal\\" to close windows 0"')} + &> /dev/null &\"") + '"; exit') + '"\''
 
     # check if cmd is built


### PR DESCRIPTION
Added config option to change Linux terminal from xterm to preferred one referred to "https://askubuntu.com/questions/46627/how-can-i-make-a-script-that-opens-terminal-windows-and-executes-commands-in-the" in how to use different terminals as reference.

I have only edited this 1 file, so if other files have similar cases (EX. gcc-make-run-view) i have no knowledge of it and i have not altered them to add this option.

Also done some preliminary testing to see if added config option works. (worked thus far in cases default "xterm" and "konsole")